### PR TITLE
feat: Add ContentImage component for handling image paths and rendering

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig({
   output: 'server',
   integrations: [
     mdx(),
-    sitemap({
+    sitemap({w
       changefreq: 'weekly',
       priority: 0.7,
       lastmod: new Date(),
@@ -35,7 +35,9 @@ export default defineConfig({
       wrap: true,
     },
   },
-
+  vite: {
+    assetsInclude: ['**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif', '**/*.svg', '**/*.webp'],
+  },
   adapter: vercel({
     webAnalytics: {
       enabled: true,

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "node migrate-images-to-public.mjs && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "migrate:images": "node migrate-images-to-public.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.0",

--- a/src/components/ContentImage.astro
+++ b/src/components/ContentImage.astro
@@ -1,0 +1,42 @@
+---
+export interface Props {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  loading?: 'lazy' | 'eager';
+  class?: string;
+}
+
+const { src, alt, width, height, loading = 'lazy', class: className } = Astro.props;
+
+// Handle relative paths for content images
+let imageSrc = src;
+if (src.startsWith('./') || src.startsWith('../')) {
+  // Convert relative paths to absolute paths
+  // This assumes images are in the content folder structure
+  const currentPath = Astro.url.pathname;
+  const blogSlug = currentPath.split('/blog/')[1]?.replace('/', '');
+  if (blogSlug && src.startsWith('./')) {
+    imageSrc = `/blog/${blogSlug}/${src.slice(2)}`;
+  }
+}
+
+// Ensure all blog images are served from public folder
+if (!imageSrc.startsWith('http') && !imageSrc.startsWith('/')) {
+  imageSrc = `/${imageSrc}`;
+}
+---
+
+<img
+  src={imageSrc}
+  alt={alt}
+  width={width}
+  height={height}
+  loading={loading}
+  decoding="async"
+  class:list={[
+    'rounded-lg shadow-sm max-w-full h-auto',
+    className
+  ]}
+/>


### PR DESCRIPTION
fix: Update build script to include image migration step
chore: Configure Vite to include image assets

Add ContentImage component and configure image handling

Introduces a ContentImage component to manage image paths and rendering, ensuring proper handling of relative paths and serving blog images from the public folder.

Updates the build script to include an image migration step for better organization and consistency.

Configures Vite to include common image asset types for improved compatibility during development and build processes.