### PR TITLE
[codex] fix post reactions after navigation

### DIFF
--- a/src/components/PostReactions.astro
+++ b/src/components/PostReactions.astro
@@ -471,14 +471,24 @@ const componentId = `reactions-${postId.replace(/[^a-zA-Z0-9]/g, '-')}`;
     }
   }
 
-  // Initialize reactions when DOM is ready
-  document.addEventListener('DOMContentLoaded', () => {
+  const initializedReactionContainers = new WeakSet<HTMLElement>();
+
+  // Initialize reactions on full page loads and Astro client-side navigations.
+  const initPostReactions = () => {
     const reactionContainers = document.querySelectorAll('.post-reactions');
     
     reactionContainers.forEach(container => {
-      new PostReactionsManager(container as HTMLElement);
+      const reactionContainer = container as HTMLElement;
+      if (initializedReactionContainers.has(reactionContainer)) return;
+
+      initializedReactionContainers.add(reactionContainer);
+      new PostReactionsManager(reactionContainer);
     });
-  });
+  };
+
+  document.addEventListener('DOMContentLoaded', initPostReactions);
+  document.addEventListener('astro:page-load', initPostReactions);
+  initPostReactions();
 
   // Export for testing
   if (typeof window !== 'undefined') {

--- a/tests/post-reactions.spec.ts
+++ b/tests/post-reactions.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Post reactions', () => {
+  test('initializes after client-side blog navigation and persists a reaction', async ({
+    page,
+  }) => {
+    await page.goto('/blog/');
+
+    await page.locator('a[href="/blog/zero-downtime-database-migration-at-scale"]').click();
+
+    await expect(page).toHaveURL(/\/blog\/zero-downtime-database-migration-at-scale\/?$/);
+
+    const helpfulButton = page.locator('.post-reactions button[data-reaction="helpful"]');
+    await expect(helpfulButton).toHaveAttribute('aria-pressed', 'false');
+
+    await helpfulButton.click();
+
+    await expect(helpfulButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(helpfulButton.locator('.reaction-count')).toHaveText('1');
+
+    await page.reload();
+
+    await expect(helpfulButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(helpfulButton.locator('.reaction-count')).toHaveText('1');
+  });
+});


### PR DESCRIPTION
## Summary
- Initialize the blog post reactions widget on Astro client-side page loads.
- Guard initialization with a WeakSet so repeated lifecycle events do not double-bind handlers.
- Add a Playwright regression test for navigating from the blog index, clicking Helpful, and preserving the reaction after reload.

## Root Cause
The component only initialized on `DOMContentLoaded`. With Astro client-side navigation, blog post markup can be swapped in after that event has already fired, leaving the Like/Helpful/Insightful buttons rendered but inert.

## Validation
- `biome check src\components\PostReactions.astro tests\post-reactions.spec.ts`
- `astro check`
- `astro build`
- `playwright test --grep "Post reactions" --project=chromium --workers=1`