### PR TITLE
fix(blog): theme vars + mobile horizontal scroll

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -386,6 +386,10 @@ const uniqueThemes = new Set(postsForFilter.flatMap((post) => post.categories)).
       width: min(100% - 1rem, 1120px);
     }
 
+    .writing-newsletter__inner {
+      grid-template-columns: 1fr;
+    }
+
     .writing-hero h1 {
       font-size: 3rem;
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -155,6 +155,11 @@
   --color-darker: #0f1221;
   --color-darker-rgb: 15, 18, 33;
   --color-navbar-bg: rgba(23, 26, 47, 0.9);
+  /* RGB triples for old newsletter/CTA styles (rgb(var(--surface) / …)) */
+  --text: 246, 247, 255;    /* --color-text-primary */
+  --surface: 34, 38, 64;    /* --color-surface-raised */
+  --border: 52, 58, 95;     /* --color-card-border */
+  --accent: 255, 204, 104;  /* --color-accent */
 }
 
 :root.professional-light,
@@ -172,6 +177,11 @@
   --color-darker: #fffaf0;
   --color-darker-rgb: 255, 250, 240;
   --color-navbar-bg: rgba(246, 243, 234, 0.9);
+  /* RGB triples for old newsletter/CTA styles */
+  --text: 18, 24, 39;       /* --color-text-primary */
+  --surface: 255, 250, 240; /* --color-surface-raised */
+  --border: 221, 211, 194;  /* --color-card-border */
+  --accent: 141, 61, 31;    /* --color-accent */
 }
 
 body {


### PR DESCRIPTION
## What
- Define missing CSS vars (`--surface`/`--text`/`--border`/`--accent`) as color triples in both themes — used in newsletter/CTA blocks but never defined, so boxes lost background/border.
- Collapse `.writing-newsletter__inner` to 1 column under 640px to kill the 139px horizontal scroll on mobile.

## Verified
Playwright at 390px mobile: scrollWidth == clientWidth on writing page + real blog post; newsletter/CTA render themed gradient.

## Scope
Only this fix — NOT the 20-commit blog/content-pack branch.