### PR TITLE
perf: prerender public pages and prioritize LCP images

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,6 +23,7 @@ export interface Props {
   keywords?: string[];
   ogTemplate?: 'default' | 'minimal' | 'tech' | 'blog' | 'modern' | 'professional';
   ogTheme?: 'dark' | 'light' | 'retro';
+  preloadImage?: string;
 }
 
 const {
@@ -40,6 +41,7 @@ const {
   keywords,
   ogTemplate = 'default',
   ogTheme = 'dark',
+  preloadImage,
 } = Astro.props;
 ---
 
@@ -59,6 +61,7 @@ const {
     <link rel="manifest" href="/manifest.json" />
     <meta name="generator" content={Astro.generator} />
     <ClientRouter />
+    {preloadImage && <link rel="preload" as="image" href={preloadImage} fetchpriority="high" />}
     <SEO
       title={title}
       description={description}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from '../layouts/Layout.astro';
 ---
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,6 +7,8 @@ import {
 } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
 
+export const prerender = true;
+
 const featuredStudies = caseStudies.slice(0, 3);
 ---
 

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -5,6 +5,8 @@ import NewsletterSignup from '../components/NewsletterSignup.tsx';
 import { writingHighlights } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
 
+export const prerender = true;
+
 const allPosts = await getCollection('blog');
 const toPostSlug = (id: string) => id.replace(/\/index$/, '').replace(/\.(md|mdx)$/, '');
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -98,6 +98,7 @@ const articleSchema = {
   schema={articleSchema}
   ogTemplate={ogTemplate}
   ogTheme={ogTheme}
+  preloadImage={image?.url}
 >
   <div class="page-container blog-post-page">
     <div class="blog-post-shell">
@@ -236,7 +237,6 @@ const articleSchema = {
                 src={image.url}
                 alt={image.alt || title}
                 class="w-full h-auto"
-                loading="lazy"
                 priority={true}
                 quality={90}
                 sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"

--- a/src/pages/contact-me.astro
+++ b/src/pages/contact-me.astro
@@ -2,6 +2,8 @@
 import ContactForm from '../components/ContactForm';
 import { contactChannels, contactPrompts, contactTopics } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,8 @@ import { caseStudies, portfolioMetrics, socialLinks, writingHighlights } from '.
 import speakerPhoto from '../images/piyush-devfest.jpg';
 import Layout from '../layouts/Layout.astro';
 
+export const prerender = true;
+
 const featuredCaseStudies = caseStudies.slice(0, 3);
 ---
 
@@ -54,7 +56,15 @@ const featuredCaseStudies = caseStudies.slice(0, 3);
     </div>
 
     <figure class="hero-portrait" data-reveal data-reveal-delay="120" data-parallax data-parallax-speed="0.08">
-      <img src={speakerPhoto.src} alt="Piyush Mehta speaking at a developer event" />
+      <img
+        src={speakerPhoto.src}
+        alt="Piyush Mehta speaking at a developer event"
+        width={speakerPhoto.width}
+        height={speakerPhoto.height}
+        loading="eager"
+        decoding="async"
+        fetchpriority="high"
+      />
       <figcaption>
         Developer education, production systems, and hands-on infrastructure practice.
       </figcaption>

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -1,6 +1,8 @@
 ---
 import NewsletterSignup from '../components/NewsletterSignup.tsx';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout

--- a/src/pages/og-showcase.astro
+++ b/src/pages/og-showcase.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from '../layouts/Layout.astro';
 
 const baseUrl = (

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from '../layouts/Layout.astro';
 ---
 

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,6 +1,8 @@
 ---
 import { caseStudies, socialLinks } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout

--- a/src/pages/react-developer.astro
+++ b/src/pages/react-developer.astro
@@ -2,6 +2,8 @@
 import { caseStudies, reactStrengths } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
 
+export const prerender = true;
+
 const keywords = [
   'React Engineering',
   'Frontend Architecture',

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -8,6 +8,8 @@ import {
   resumeSkillGroups,
 } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -7,6 +7,8 @@ import {
 } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
 
+export const prerender = true;
+
 const keywords = [
   'Software Engineering',
   'Technical Consulting',

--- a/src/pages/terms-of-service.astro
+++ b/src/pages/terms-of-service.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = true;
+
 import Layout from '../layouts/Layout.astro';
 ---
 

--- a/src/pages/uses.astro
+++ b/src/pages/uses.astro
@@ -1,6 +1,8 @@
 ---
 import { setupPrinciples, usesCategories } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout

--- a/src/pages/videos.astro
+++ b/src/pages/videos.astro
@@ -1,6 +1,8 @@
 ---
 import { videoHighlights, writingHighlights } from '../data/portfolio';
 import Layout from '../layouts/Layout.astro';
+
+export const prerender = true;
 ---
 
 <Layout


### PR DESCRIPTION
## Summary
- prerender public content and marketing routes so Vercel serves static CDN output
- preload each blog post hero image and prioritize its fetch
- mark the homepage portrait as an eager, dimensioned LCP candidate

## Validation
- `bunx biome check` passed for the touched files
- pre-commit React Doctor passed (100/100)
- `bun run build` passed; static output was verified for `/`, `/resume`, and the slow CSP and migration posts

## Notes
- The optional resume PDF build step cannot run locally because the Playwright Chromium binary is not installed.
- `bunx astro check` currently crashes in the Astro language server (`fileExists` undefined), while the production build succeeds.