### PR TITLE
feat: support Dark Reader native themes

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -103,6 +103,12 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
   (() => {
     const root = document.documentElement;
 
+    function syncColorScheme(isDark) {
+      const colorScheme = isDark ? 'dark' : 'light';
+      root.style.colorScheme = colorScheme;
+      document.querySelector('meta[name="color-scheme"]')?.setAttribute('content', colorScheme);
+    }
+
     function syncIcons() {
       const btn = document.getElementById('theme-toggle-btn');
       const sun = btn?.querySelector('.theme-icon-sun');
@@ -132,6 +138,7 @@ const isActive = (href: string) => (href === '/' ? pathname === '/' : pathname.s
         root.classList.remove('light');
         localStorage.setItem('theme', 'professional-dark');
       }
+      syncColorScheme(!currentlyDark);
       syncIcons();
       btn.style.transform = 'scale(0.9)';
       setTimeout(() => { btn.style.transform = ''; }, 150);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,6 +51,7 @@ const {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <link rel="icon" type="image/svg+xml" href={favicon.src} />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link
@@ -87,8 +88,11 @@ const {
           (window.matchMedia('(prefers-color-scheme: light)').matches
             ? 'professional-light'
             : 'professional-dark');
+        const colorScheme = preferredTheme === 'professional-light' ? 'light' : 'dark';
         document.documentElement.classList.remove('professional-dark', 'professional-light', 'light', 'dark');
         document.documentElement.classList.add(preferredTheme);
+        document.documentElement.style.colorScheme = colorScheme;
+        document.querySelector('meta[name="color-scheme"]')?.setAttribute('content', colorScheme);
         if (preferredTheme === 'professional-light') {
           document.documentElement.classList.add('light');
         }

--- a/tests/theme-navigation.spec.ts
+++ b/tests/theme-navigation.spec.ts
@@ -1,12 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-test('theme toggle works after client-side navigation', async ({ page }) => {
+test('theme toggle maintains Dark Reader color scheme detection after client-side navigation', async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem('theme', 'professional-dark'));
   await page.goto('/');
   await page.getByLabel('Primary navigation').getByRole('link', { name: 'Work' }).click();
   await expect(page).toHaveURL(/\/projects\/?$/);
   await expect(page.locator('html')).toHaveClass(/professional-dark/);
+  await expect(page.locator('meta[name="color-scheme"]')).toHaveAttribute('content', 'dark');
+  await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
 
   await page.getByRole('button', { name: 'Toggle theme' }).click();
   await expect(page.locator('html')).toHaveClass(/professional-light/);
+  await expect(page.locator('meta[name="color-scheme"]')).toHaveAttribute('content', 'light');
+  await expect(page.locator('html')).toHaveCSS('color-scheme', 'light');
 });


### PR DESCRIPTION
## Description

Adds native color-scheme signals so Dark Reader recognizes the site’s active light or dark theme and avoids applying a second dark transformation.

## Changes Made

- Add and synchronize `meta[name="color-scheme"]` with the active site theme.
- Set the document color scheme during initial render and after theme toggles.
- Cover both dark and light states after client-side navigation.

## Testing

- [x] Local development
- [x] `bunx playwright test tests/theme-navigation.spec.ts --project=chromium`

## Documentation

- [x] No documentation update required.