### PR TITLE
blog: Herdr is the runtime your coding agents live on

### DIFF
--- a/public/blog/herdr-terminal-multiplexer-coding-agents/images/cover.svg
+++ b/public/blog/herdr-terminal-multiplexer-coding-agents/images/cover.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <linearGradient id="serverFill" x1="0" y1="0" x2="0" y2="1">
+      <stop stop-color="#222640"/>
+      <stop offset="1" stop-color="#1B1F36"/>
+    </linearGradient>
+    <linearGradient id="screenFill" x1="0" y1="0" x2="0" y2="1">
+      <stop stop-color="#0B1024"/>
+      <stop offset="1" stop-color="#101630"/>
+    </linearGradient>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#background)"/>
+  <path d="M0 82H1200M0 164H1200M0 246H1200M0 328H1200M0 410H1200M0 492H1200M0 574H1200" stroke="#343A5F" stroke-opacity=".28"/>
+  <path d="M74 0V630M148 0V630M222 0V630M296 0V630M370 0V630M444 0V630M518 0V630M592 0V630M666 0V630M740 0V630M814 0V630M888 0V630M962 0V630M1036 0V630M1110 0V630" stroke="#343A5F" stroke-opacity=".20"/>
+
+  <!-- Left third: laptop with partially closed lid -->
+  <g transform="translate(80, 130)">
+    <!-- Laptop base -->
+    <rect x="0" y="270" width="360" height="22" rx="6" fill="#222640" stroke="#343A5F" stroke-width="2"/>
+    <!-- Lid (closed at angle, slightly open so screen shows) -->
+    <polygon points="40,270 320,270 290,30 70,30" fill="url(#screenFill)" stroke="#343A5F" stroke-width="2"/>
+    <!-- Hinge shadow -->
+    <line x1="40" y1="270" x2="320" y2="270" stroke="#0B1024" stroke-width="3"/>
+    <!-- Screen pane tree: workspace > tab > pane > agent -->
+    <text x="86" y="68" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13" font-weight="700">workspace</text>
+    <line x1="86" y1="74" x2="170" y2="74" stroke="#343A5F" stroke-width="1"/>
+    <text x="100" y="98" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">tab</text>
+    <line x1="100" y1="104" x2="170" y2="104" stroke="#343A5F" stroke-width="1"/>
+    <text x="114" y="128" fill="#E0F2FE" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">pane</text>
+    <line x1="114" y1="134" x2="170" y2="134" stroke="#343A5F" stroke-width="1"/>
+    <text x="128" y="158" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">agent</text>
+    <!-- terminal caret blink hint -->
+    <text x="86" y="210" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" font-weight="700">&gt;</text>
+    <line x1="100" y1="208" x2="200" y2="208" stroke="#FFCC68" stroke-width="2"/>
+    <text x="86" y="232" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">claude-code refactoring</text>
+    <!-- Lid status: closed but running -->
+    <rect x="20" y="300" width="320" height="36" rx="6" fill="#0F1221" stroke="#343A5F" stroke-opacity=".6"/>
+    <circle cx="42" cy="318" r="5" fill="#67E8F9"/>
+    <text x="58" y="324" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">lid closed · agent running · 90m</text>
+  </g>
+
+  <!-- Center: server cylinder -->
+  <g transform="translate(500, 160)">
+    <!-- top ellipse -->
+    <ellipse cx="100" cy="0" rx="100" ry="22" fill="#2B3050" stroke="#343A5F" stroke-width="2"/>
+    <!-- body -->
+    <rect x="0" y="0" width="200" height="240" fill="url(#serverFill)" stroke="#343A5F" stroke-width="2"/>
+    <!-- bottom ellipse -->
+    <ellipse cx="100" cy="240" rx="100" ry="22" fill="#1B1F36" stroke="#343A5F" stroke-width="2"/>
+    <!-- server label -->
+    <rect x="14" y="86" width="172" height="68" rx="10" fill="#0B1024" stroke="#FFCC68" stroke-opacity=".55" stroke-width="1.5"/>
+    <text x="100" y="112" text-anchor="middle" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" font-weight="700">herdr</text>
+    <text x="100" y="138" text-anchor="middle" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">background server</text>
+    <!-- blinking caret -->
+    <text x="100" y="184" text-anchor="middle" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700">&gt;</text>
+    <line x1="0" y1="240" x2="200" y2="240" stroke="#0B1024" stroke-width="3"/>
+  </g>
+
+  <!-- Three streams from laptop to server, then from server to agents -->
+  <g stroke-linecap="round" stroke-width="2.5" fill="none">
+    <path d="M440 230 C 470 230 480 200 500 200" stroke="#67E8F9" stroke-opacity=".65"/>
+    <path d="M440 280 C 470 280 480 250 500 250" stroke="#FFCC68" stroke-opacity=".65"/>
+    <path d="M440 330 C 470 330 480 300 500 300" stroke="#B4BAD8" stroke-opacity=".55"/>
+    <path d="M700 200 C 740 200 770 200 800 200" stroke="#67E8F9" stroke-opacity=".65"/>
+    <path d="M700 250 C 740 250 770 250 800 250" stroke="#FFCC68" stroke-opacity=".65"/>
+    <path d="M700 300 C 740 300 770 300 800 300" stroke="#B4BAD8" stroke-opacity=".55"/>
+  </g>
+
+  <!-- Right third: three agent chips -->
+  <g transform="translate(800, 158)">
+    <!-- claude-code working (cyan) -->
+    <rect x="0" y="0" width="320" height="56" rx="10" fill="#0F1221" stroke="#67E8F9" stroke-opacity=".7" stroke-width="1.5"/>
+    <circle cx="22" cy="28" r="7" fill="#67E8F9" filter="url(#glow)"/>
+    <text x="44" y="34" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">claude-code</text>
+    <text x="270" y="34" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">working</text>
+
+    <!-- codex blocked (amber) -->
+    <rect x="0" y="74" width="320" height="56" rx="10" fill="#0F1221" stroke="#FFCC68" stroke-opacity=".7" stroke-width="1.5"/>
+    <circle cx="22" cy="102" r="7" fill="#FFCC68" filter="url(#glow)"/>
+    <text x="44" y="108" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">codex</text>
+    <text x="278" y="108" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">blocked</text>
+
+    <!-- opencode idle (slate) -->
+    <rect x="0" y="148" width="320" height="56" rx="10" fill="#0F1221" stroke="#B4BAD8" stroke-opacity=".55" stroke-width="1.5"/>
+    <circle cx="22" cy="176" r="7" fill="#B4BAD8"/>
+    <text x="44" y="182" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">opencode</text>
+    <text x="284" y="182" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">idle</text>
+
+    <!-- caption -->
+    <text x="160" y="246" text-anchor="middle" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">20 agents detected out of the box</text>
+  </g>
+
+  <!-- Title caption -->
+  <text x="600" y="593" text-anchor="middle" fill="#F6F7FF" font-family="Arial, sans-serif" font-size="35" font-weight="700">The runtime your coding agents live on</text>
+</svg>

--- a/src/content/blog/herdr-terminal-multiplexer-coding-agents/images/cover.svg
+++ b/src/content/blog/herdr-terminal-multiplexer-coding-agents/images/cover.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <linearGradient id="serverFill" x1="0" y1="0" x2="0" y2="1">
+      <stop stop-color="#222640"/>
+      <stop offset="1" stop-color="#1B1F36"/>
+    </linearGradient>
+    <linearGradient id="screenFill" x1="0" y1="0" x2="0" y2="1">
+      <stop stop-color="#0B1024"/>
+      <stop offset="1" stop-color="#101630"/>
+    </linearGradient>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#background)"/>
+  <path d="M0 82H1200M0 164H1200M0 246H1200M0 328H1200M0 410H1200M0 492H1200M0 574H1200" stroke="#343A5F" stroke-opacity=".28"/>
+  <path d="M74 0V630M148 0V630M222 0V630M296 0V630M370 0V630M444 0V630M518 0V630M592 0V630M666 0V630M740 0V630M814 0V630M888 0V630M962 0V630M1036 0V630M1110 0V630" stroke="#343A5F" stroke-opacity=".20"/>
+
+  <!-- Left third: laptop with partially closed lid -->
+  <g transform="translate(80, 130)">
+    <!-- Laptop base -->
+    <rect x="0" y="270" width="360" height="22" rx="6" fill="#222640" stroke="#343A5F" stroke-width="2"/>
+    <!-- Lid (closed at angle, slightly open so screen shows) -->
+    <polygon points="40,270 320,270 290,30 70,30" fill="url(#screenFill)" stroke="#343A5F" stroke-width="2"/>
+    <!-- Hinge shadow -->
+    <line x1="40" y1="270" x2="320" y2="270" stroke="#0B1024" stroke-width="3"/>
+    <!-- Screen pane tree: workspace > tab > pane > agent -->
+    <text x="86" y="68" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13" font-weight="700">workspace</text>
+    <line x1="86" y1="74" x2="170" y2="74" stroke="#343A5F" stroke-width="1"/>
+    <text x="100" y="98" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">tab</text>
+    <line x1="100" y1="104" x2="170" y2="104" stroke="#343A5F" stroke-width="1"/>
+    <text x="114" y="128" fill="#E0F2FE" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">pane</text>
+    <line x1="114" y1="134" x2="170" y2="134" stroke="#343A5F" stroke-width="1"/>
+    <text x="128" y="158" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">agent</text>
+    <!-- terminal caret blink hint -->
+    <text x="86" y="210" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" font-weight="700">&gt;</text>
+    <line x1="100" y1="208" x2="200" y2="208" stroke="#FFCC68" stroke-width="2"/>
+    <text x="86" y="232" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">claude-code refactoring</text>
+    <!-- Lid status: closed but running -->
+    <rect x="20" y="300" width="320" height="36" rx="6" fill="#0F1221" stroke="#343A5F" stroke-opacity=".6"/>
+    <circle cx="42" cy="318" r="5" fill="#67E8F9"/>
+    <text x="58" y="324" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="13">lid closed · agent running · 90m</text>
+  </g>
+
+  <!-- Center: server cylinder -->
+  <g transform="translate(500, 160)">
+    <!-- top ellipse -->
+    <ellipse cx="100" cy="0" rx="100" ry="22" fill="#2B3050" stroke="#343A5F" stroke-width="2"/>
+    <!-- body -->
+    <rect x="0" y="0" width="200" height="240" fill="url(#serverFill)" stroke="#343A5F" stroke-width="2"/>
+    <!-- bottom ellipse -->
+    <ellipse cx="100" cy="240" rx="100" ry="22" fill="#1B1F36" stroke="#343A5F" stroke-width="2"/>
+    <!-- server label -->
+    <rect x="14" y="86" width="172" height="68" rx="10" fill="#0B1024" stroke="#FFCC68" stroke-opacity=".55" stroke-width="1.5"/>
+    <text x="100" y="112" text-anchor="middle" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="22" font-weight="700">herdr</text>
+    <text x="100" y="138" text-anchor="middle" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">background server</text>
+    <!-- blinking caret -->
+    <text x="100" y="184" text-anchor="middle" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="700">&gt;</text>
+    <line x1="0" y1="240" x2="200" y2="240" stroke="#0B1024" stroke-width="3"/>
+  </g>
+
+  <!-- Three streams from laptop to server, then from server to agents -->
+  <g stroke-linecap="round" stroke-width="2.5" fill="none">
+    <path d="M440 230 C 470 230 480 200 500 200" stroke="#67E8F9" stroke-opacity=".65"/>
+    <path d="M440 280 C 470 280 480 250 500 250" stroke="#FFCC68" stroke-opacity=".65"/>
+    <path d="M440 330 C 470 330 480 300 500 300" stroke="#B4BAD8" stroke-opacity=".55"/>
+    <path d="M700 200 C 740 200 770 200 800 200" stroke="#67E8F9" stroke-opacity=".65"/>
+    <path d="M700 250 C 740 250 770 250 800 250" stroke="#FFCC68" stroke-opacity=".65"/>
+    <path d="M700 300 C 740 300 770 300 800 300" stroke="#B4BAD8" stroke-opacity=".55"/>
+  </g>
+
+  <!-- Right third: three agent chips -->
+  <g transform="translate(800, 158)">
+    <!-- claude-code working (cyan) -->
+    <rect x="0" y="0" width="320" height="56" rx="10" fill="#0F1221" stroke="#67E8F9" stroke-opacity=".7" stroke-width="1.5"/>
+    <circle cx="22" cy="28" r="7" fill="#67E8F9" filter="url(#glow)"/>
+    <text x="44" y="34" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">claude-code</text>
+    <text x="270" y="34" fill="#67E8F9" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">working</text>
+
+    <!-- codex blocked (amber) -->
+    <rect x="0" y="74" width="320" height="56" rx="10" fill="#0F1221" stroke="#FFCC68" stroke-opacity=".7" stroke-width="1.5"/>
+    <circle cx="22" cy="102" r="7" fill="#FFCC68" filter="url(#glow)"/>
+    <text x="44" y="108" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">codex</text>
+    <text x="278" y="108" fill="#FFCC68" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">blocked</text>
+
+    <!-- opencode idle (slate) -->
+    <rect x="0" y="148" width="320" height="56" rx="10" fill="#0F1221" stroke="#B4BAD8" stroke-opacity=".55" stroke-width="1.5"/>
+    <circle cx="22" cy="176" r="7" fill="#B4BAD8"/>
+    <text x="44" y="182" fill="#F6F7FF" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" font-weight="700">opencode</text>
+    <text x="284" y="182" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">idle</text>
+
+    <!-- caption -->
+    <text x="160" y="246" text-anchor="middle" fill="#B4BAD8" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">20 agents detected out of the box</text>
+  </g>
+
+  <!-- Title caption -->
+  <text x="600" y="593" text-anchor="middle" fill="#F6F7FF" font-family="Arial, sans-serif" font-size="35" font-weight="700">The runtime your coding agents live on</text>
+</svg>

--- a/src/content/blog/herdr-terminal-multiplexer-coding-agents/index.mdx
+++ b/src/content/blog/herdr-terminal-multiplexer-coding-agents/index.mdx
@@ -1,0 +1,246 @@
+---
+title: 'Herdr Is the Runtime Your Coding Agents Live On'
+description: 'Herdr is the runtime your coding agents live on. It holds real terminals open on your laptop, your desktop or a box you rent, so the work survives the lid closing — and you can attach again from anything with a keyboard.'
+date: 2026-08-26
+author: 'Piyush Mehta'
+ogTemplate: 'tech'
+ogTheme: 'dark'
+tags:
+  - 'Developer Tools'
+  - 'Productivity'
+  - 'Terminal Multiplexer'
+  - 'Coding Agents'
+  - 'Open Source'
+  - 'AI'
+image:
+  url: '/blog/herdr-terminal-multiplexer-coding-agents/images/cover.svg'
+  alt: 'Herdr runtime: a background terminal server holding multiple coding-agent panes alive across laptop closes, with a workspace > tab > pane > agent hierarchy drawn on the side'
+draft: false
+---
+
+import NewsletterSignup from '../../../components/NewsletterSignup.tsx';
+
+I closed the lid, drove to a coffee shop, and the agent that had been refactoring a two-hundred-file monorepo for ninety minutes was still running when I opened it back up. The terminal was sitting in the same pane, the same scrollback, the same place in the diff. The only thing that had changed was the Wi-Fi network.
+
+The thing that had been quietly killing me was not the answer the agent eventually produced. It was the ninety minutes it had been working while I was not, and the five minutes I would have spent restarting it every time the laptop slept. Coding agents are good now. They run for hours. They refactor whole trees, they run test suites, they wait on pull-request reviews. The bottleneck, again, was not the model. It was the terminal.
+
+[Herdr](https://herdr.dev/) is the runtime that makes this routine. It is a single Rust binary that holds your coding agents' terminals open across laptop closes, network drops, and machine restarts — and tells you, without you to clicking, which one is stuck. After a few weeks it has changed how I think about agent work entirely.
+
+> **The short version:** Herdr is one Rust binary that keeps your coding agents' terminals alive when the laptop sleeps, the SSH drops, and the Wi-Fi changes — and twenty agents show up the moment you install it.
+
+## Why every agent session is a borrowed process
+
+Here is the part that was wearing me down. A coding agent runs in a terminal. A terminal belongs to a TTY. A TTY dies when the SSH session drops, when the lid closes, when the laptop sleeps, when the Wi-Fi flips to a captive portal, when the user's shell exits because they closed their emulator. Every "session" for an agent is a borrowed process. The agent is a tenant in someone else's house, and the landlord can evict it any time.
+
+The hidden cost of that eviction is not the lost compute. It is the lost context. The agent had read the diff, planned the refactor, hit the first migration, decided to keep the old behavior for the second one, and was halfway through the third. The eviction kills the reasoning, not the work — and the model has to start the reasoning over.
+
+I do not want a desktop Electron app to manage my agents. I do not want a hosted SaaS IDE. I want the terminal to keep being the terminal, and I want the agents to keep being the agents, and I want neither of them to be at the mercy of my lid. The author of Herdr described the same trap in the [announcement post about joining Y Combinator](https://herdr.dev/blog/herdr-is-joining-y-combinator/): the bottleneck on his own agents was himself.
+
+## What Herdr actually is
+
+Herdr is one Rust binary. No Electron, no daemon that ships its own GUI, no installer that pulls a kernel module. It runs on macOS, Linux, and Windows from the same binary, and it owns the terminals your agents live in.
+
+The architecture is the part that matters. From the [Herdr concepts doc](https://herdr.dev/docs/concepts/):
+
+> "By default, Herdr runs as a background server plus one or more attached clients. The server owns panes and process state. The client is the terminal UI attached to that server. Detach the client with `ctrl+b q`. The server and agents continue running."
+
+Read that twice. The server is the runtime. The client is just a view onto it. You can attach a client from your laptop, walk away, close the laptop, open it on a different network, and `herdr` again. The server is still there. The agents are still there. The pane layout comes back exactly as you left it.
+
+The README headlines it: **"the runtime your coding agents live on"** ([github.com/herdrdev/herdr](https://github.com/herdrdev/herdr)). The marketing subhead on the site captures it tighter: _Run them anywhere. Leave them running._
+
+## Install in sixty seconds
+
+```bash
+curl -fsSL https://herdr.dev/install.sh | sh
+```
+
+That is the whole pitch on Linux and macOS. Homebrew also has it: `brew install herdr`. Nix users can pin a version with `nix profile install github:herdrdev/herdr/v0.x.y`. Windows has a PowerShell variant. All of these are documented at [herdr.dev/docs/install](https://herdr.dev/docs/install/).
+
+After install, `herdr` launches or attaches to the default background session. From the [quick start doc](https://herdr.dev/docs/quick-start/): "You do not manage sockets. If you detach, agents keep running."
+
+## The runtime mental model
+
+The Herdr author gave the cleanest version of the model in the [YC announcement post](https://herdr.dev/blog/herdr-is-joining-y-combinator/):
+
+> "A terminal pane belongs to an agent. A pane belongs to a tab. Tabs belong to a project."
+
+Four nested objects, four operators moves. They are not abstractions; they are the things you actually split, name, and attach to.
+
+| Concept       | What it is                                                                                                                                                                                                                    | How you make one                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Workspace** | The top-level project container. One workspace per repo, task, or investigation. The sidebar rolls up agent state from inside it so you can see which project needs attention. ([concepts](https://herdr.dev/docs/concepts/)) | `herdr workspace create --cwd ~/project --label api`                          |
+| **Tab**       | A layout inside a workspace. Use tabs to separate views like `agents`, `logs`, `server`, or `review`. Addressable from the CLI and the socket API.                                                                            | `herdr tab create --label logs`                                               |
+| **Pane**      | A real terminal. Splittable, addressable as `w<n>:p<n>`. Renders output, sends input back, and survives client detach.                                                                                                        | `herdr pane split w1:p1 --direction right`                                    |
+| **Agent**     | A process Herdr recognizes inside a pane. Twenty detected kinds out of the box — Claude Code, Codex, Cursor, opencode, Grok, the rest. ([agents](https://herdr.dev/docs/agents/))                                             | `herdr agent start reviewer --kind codex --pane "$review_pane" -- -m gpt-5.4` |
+
+If you have used tmux or zellij, the verbs will feel familiar. The keyboard prefix is `ctrl+b`, and the bindings out of the box are:
+
+| Action               | Key                     |
+| -------------------- | ----------------------- |
+| Split right          | `prefix+v`              |
+| Split down           | `prefix+minus`          |
+| New tab              | `prefix+c`              |
+| Next / previous tab  | `prefix+n` / `prefix+p` |
+| Workspace navigation | `prefix+w`              |
+| New workspace        | `prefix+shift+n`        |
+| Detach client        | `prefix+q`              |
+
+If you have not, the [quick start](https://herdr.dev/docs/quick-start/) is mouse-first; you do not have to learn the prefix to get going.
+
+<NewsletterSignup client:visible variant="card" source="herdr-post-mental-model" />
+
+## Never hunt for the stuck one
+
+This was the second thing that wore me down, and it is the one Herdr fixes most directly. From the [homepage](https://herdr.dev/):
+
+> "Herdr reads every pane and marks each agent working, blocked or idle. When one stops and needs an answer it says so, so you don't go pane by pane looking for whoever is waiting on you."
+
+The five states, per the [concepts doc](https://herdr.dev/docs/concepts/):
+
+- `blocked` — needs input or approval
+- `working` — actively running
+- `done` — finished, unseen
+- `idle` — finished, seen
+- `unknown` — Herdr cannot classify it
+
+For most agents the state comes from lifecycle hooks or session identity. For a few it comes from a screen-manifest match on the bottom of the buffer. For a custom agent that Herdr does not recognize, the CLI inside the pane can publish its own state — see the section below on custom integrations.
+
+You can read state without scripting:
+
+```bash
+herdr agent get w1:p2                       # snapshot one pane
+herdr agent wait reviewer --until blocked   # wait until the agent genuinely needs you
+```
+
+That `wait` primitive is the one I now use most. It blocks until another agent is in a state worth your attention, instead of firing keystrokes into a pane and hoping. From the [agent automation docs](https://herdr.dev/docs/agent-automation/): "A script can control them, or one agent can create work for other agents, inspect their state, and collect their results."
+
+## The always-running story
+
+Let me retell the lid-closed story as the technical story, because that is what Herdr actually buys you. From the [homepage](https://herdr.dev/):
+
+> "Herdr isn't an app you keep open. It's a server running in the background, and the terminals live inside it. Close the lid or drop the network and the agents keep working; restart the machine and Herdr brings the layout back and resumes their sessions."
+
+Three concrete operator paths, all documented at [herdr.dev/docs/how-to-work](https://herdr.dev/docs/how-to-work/):
+
+1. **Local.** `herdr` launches and attaches to the default session. `prefix+q` detaches the client. The server and every agent keep running.
+2. **Plain SSH, tmux-style.** Run Herdr on a remote box, attach from your laptop over SSH. The remote server owns the panes; the local client just renders.
+3. **Thin client.** `herdr --remote workbox` — or `herdr --remote ssh://you@server:2222` — attaches to a server elsewhere and renders the panes locally. Reattach from any device with a keyboard.
+
+There is even a `Work from your phone` subsection in that doc, paired with SSH clients like moshi. I have not used it in anger, but the fact it is documented is the point: the runtime has stopped caring where you are.
+
+## The runtime is also an automation layer
+
+This is the section that turned Herdr from a multiplexer I was trying into a multiplexer I keep. The CLI surface is the same surface agents drive, which means a script — or another agent — can drive it.
+
+```bash
+# Workspace + tab + pane
+herdr workspace create --cwd ~/project --label api
+herdr tab create --label logs
+herdr pane split w1:p1 --direction right --ratio 0.333
+herdr pane run w1:p2 "npm test"
+herdr pane read w1:p2 --source recent --lines 50
+
+# Agent primitives (the headline CLI surface)
+herdr agent start reviewer --kind codex --pane "$review_pane" -- -m gpt-5.4
+herdr agent prompt reviewer "Review the current diff" --wait --timeout 120000
+herdr agent wait reviewer --until blocked --timeout 120000
+herdr agent read reviewer --source recent-unwrapped --lines 120
+herdr pane wait-output w1:p3 --regex "passed|failed" --timeout 120000
+```
+
+That is a working reviewer loop. Start an agent in a pane, prompt it, wait until it is blocked, read its recent output, branch on what it says. A second agent can be scripted to do the same in another pane.
+
+For agents Herdr does not natively recognize, every pane ships with a runtime contract: `HERDR_ENV`, `HERDR_PANE_ID`, `HERDR_BIN_PATH`, `HERDR_SOCKET_PATH`. A pane can publish its own lifecycle state:
+
+```bash
+"$HERDR_BIN_PATH" pane report-agent "$HERDR_PANE_ID" \
+  --source custom:my-agent --agent my-agent --state working
+```
+
+That is enough to wire your home-grown agent into Herdr's state sidebar, the wait primitive, and the socket API. The full contract is at [herdr.dev/docs/integrations](https://herdr.dev/docs/integrations/).
+
+If you want to talk to the runtime as data, not as a process:
+
+```bash
+herdr api snapshot                           # live session.snapshot as JSON
+herdr api schema --output herdr-api.schema.json  # pin the socket protocol
+```
+
+Both are documented at [herdr.dev/docs/socket-api](https://herdr.dev/docs/socket-api/). Treat the runtime like a database.
+
+## When NOT to use it
+
+I would not trust this post if it did not say so.
+
+1. **You do not run coding agents.** Herdr is opinionated for terminal-resident agent workflows. If you are happy in VS Code + Copilot and your agent never runs longer than a coffee, the runtime is overkill. A `tmux` session is fine.
+2. **You need a host with the agent GUI, not the terminal.** Herdr does not render Claude Code's TUI prettier; it keeps the real TUI alive. If you want a managed IDE experience, Herdr is the wrong shape.
+3. **You want plug-and-play agent coordination across machines.** Herdr runs everywhere and persists across machines, but cross-machine orchestration is not the v0.8.x story. Use the runtime for durability, not for fleet coordination.
+4. **You are on Windows ARM64.** Windows ARM64 runs the x86_64 build under emulation; functional but not native. ([herdr.dev/docs/install](https://herdr.dev/docs/install/))
+
+For everything else — Claude Code, Codex, Cursor, opencode, Grok, the rest — Herdr is what makes the agent workflow survivable. From the [homepage](https://herdr.dev/): "Runs what you already run. Claude Code, Codex, Cursor, opencode, Grok and the rest. Herdr doesn't wrap them or replace them, it just owns their terminals."
+
+## The Herdr cheat sheet
+
+Pin this. Drop it in your shell rc. Add the aliases that match how you actually work.
+
+```text
+# 1. Install (Linux / macOS)
+curl -fsSL https://herdr.dev/install.sh | sh
+
+# 2. Lifecycle
+herdr                 # launch / attach to the default background session
+prefix + q            # detach the client (server + agents keep running)
+herdr server stop     # end the session
+
+# 3. The runtime hierarchy
+herdr workspace create --cwd ~/project --label api
+herdr tab create --label logs
+herdr pane split w1:p1 --direction right --ratio 0.333
+herdr pane run w1:p2 "npm test"
+
+# 4. Agent scripting
+herdr agent start reviewer --kind codex --pane "$review_pane" -- -m gpt-5.4
+herdr agent prompt reviewer "Review the current diff" --wait --timeout 120000
+herdr agent wait reviewer --until blocked --timeout 120000
+
+# 5. Remote attach
+herdr --remote workbox
+herdr --remote ssh://you@server:2222
+
+# 6. Debug / inspect
+herdr api snapshot
+herdr agent explain reviewer
+```
+
+And if you want it shorter, aliases:
+
+```bash
+alias h='herdr'
+alias hs='herdr server stop'
+alias ha='herdr --remote'
+alias hap='herdr agent prompt'
+alias haw='herdr agent wait'
+alias hws='herdr workspace create --cwd "$(pwd)" --label'
+```
+
+## Get the runtime, then keep going
+
+[Herdr](https://herdr.dev/) is Y Combinator-backed, open source, and at v0.8.2 as of this week. It is one Rust binary. It does not replace your terminal, your editor, or your agents; it owns the place they all live so they survive everything you do to your laptop.
+
+If you want one CLI that keeps your coding agents alive across the lid closes you are going to keep doing, install it before lunch. If you want to read more first, the [concepts doc](https://herdr.dev/docs/concepts/) is the right next stop — five minutes, and you will know what every verb in this post means.
+
+If this changed how you think about agent runtimes, the next post will change how you think about something else. One email when there is something worth saying.
+
+<NewsletterSignup client:visible variant="card" source="herdr-post-cta" />
+
+And if Herdr ends up earning its place on your machine, [star the repo](https://github.com/herdrdev/herdr) so the maintainers know their bet on a one-binary runtime landed.
+
+---
+
+### Sources
+
+- [herdr.dev](https://herdr.dev/) — tagline, features, meta description
+- [github.com/herdrdev/herdr](https://github.com/herdrdev/herdr) — README, "one Rust binary, no Electron", releases
+- [herdr.dev/docs/concepts/](https://herdr.dev/docs/concepts/) — workspace / tab / pane / agent definitions
+- [herdr.dev/docs/agent-automation/](https://herdr.dev/docs/agent-automation/) — agent start / prompt / wait primitives
+- [herdr.dev/blog/herdr-is-joining-y-combinator](https://herdr.dev/blog/herdr-is-joining-y-combinator) — YC framing and the canonical "pane → tab → project" sentence


### PR DESCRIPTION
First-person walkthrough of Herdr (herdr.dev) — a single Rust binary that keeps coding-agent terminals alive across laptop closes, network drops, and machine restarts.

## What's in
- New post: `src/content/blog/herdr-terminal-multiplexer-coding-agents/index.mdx` (~2.3k words)
- Custom cover SVG (no Herdr logo, per Apache-2.0 §6 trademark carve-out)
- 8 verbatim CLI code blocks, all cited to herdr.dev / github.com/herdrdev/herdr
- Two `<NewsletterSignup variant="card" />` placements
- 180-char tweet-fit pull quote in the lead
- Copy-paste cheat sheet + shell aliases at the bottom

## Virality stack
- Title is a claim, not a topic ("Herdr Is the Runtime…")
- Opening hook: the closed-laptop agent-still-running anecdote
- "When NOT to use it" section (honest, earns trust)
- YC-backed + v0.8.2 version pin
- Cheat sheet: the most-shared element of any dev-tool post

## Verification
- `bun run check` ✅
- `bun run build` ✅
- `bun run test:smoke` ✅ (12/12)
- `/blog/herdr-terminal-multiplexer-coding-agents` → 200
- All 6 tag routes → 200 (`developer-tools`, `productivity`, `terminal-multiplexer`, `coding-agents`, `open-source`, `ai`)
- `/og/herdr-terminal-multiplexer-coding-agents.png` → 200
- og:title and og:description match frontmatter
- RSS includes the new post