### PR TITLE
feat(blog): add RAG vs long context article

### DIFF
--- a/public/blog/rag-vs-long-context/images/cover.svg
+++ b/public/blog/rag-vs-long-context/images/cover.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">RAG vs. Long Context</title>
+  <desc id="desc">A dark two-panel comparison showing all documents entering one long context window on the left, and retrieval selecting passages before the model on the right.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#222640"/>
+      <stop offset="1" stop-color="#1B1F36"/>
+    </linearGradient>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#343A5F" stroke-opacity=".2"/>
+    </pattern>
+    <filter id="glowCyan" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowAmber" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowCyan" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#67E8F9"/>
+    </marker>
+    <marker id="arrowAmber" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#FFCC68"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .muted { fill: #8F96BA; }
+      .secondary { fill: #B4BAD8; }
+      .primary { fill: #F6F7FF; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="500" fill="url(#grid)"/>
+
+  <rect x="44" y="42" width="508" height="420" rx="12" fill="url(#panel)" stroke="#343A5F" stroke-width="2"/>
+  <rect x="648" y="42" width="508" height="420" rx="12" fill="url(#panel)" stroke="#343A5F" stroke-width="2"/>
+
+  <text x="76" y="82" font-size="18" font-weight="700" letter-spacing="2" fill="#67E8F9">LONG CONTEXT</text>
+  <circle cx="518" cy="76" r="4" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="680" y="82" font-size="18" font-weight="700" letter-spacing="2" fill="#FFCC68">RAG</text>
+  <circle cx="1122" cy="76" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+
+  <rect x="86" y="104" width="424" height="246" rx="10" fill="#0B1024" stroke="#67E8F9" stroke-opacity=".55" stroke-width="2"/>
+  <text x="108" y="132" font-size="12" letter-spacing="1" fill="#8F96BA">context window / one prompt</text>
+  <rect x="108" y="148" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="108" y="208" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="108" y="268" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <circle cx="128" cy="172" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <circle cx="128" cy="232" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <circle cx="128" cy="292" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="146" y="177" font-size="14" class="primary">document 01</text>
+  <text x="146" y="237" font-size="14" class="primary">document 02</text>
+  <text x="146" y="297" font-size="14" class="primary">document 03</text>
+  <text x="476" y="177" text-anchor="end" font-size="12" class="muted">fits</text>
+  <text x="476" y="237" text-anchor="end" font-size="12" class="muted">fits</text>
+  <text x="476" y="297" text-anchor="end" font-size="12" class="muted">fits</text>
+  <line x1="298" y1="350" x2="298" y2="374" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrowCyan)"/>
+  <rect x="220" y="382" width="156" height="42" rx="21" fill="#0F1221" stroke="#67E8F9" stroke-width="2"/>
+  <circle cx="244" cy="403" r="4" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="260" y="408" font-size="15" class="primary">model</text>
+
+  <rect x="690" y="104" width="424" height="246" rx="10" fill="#0B1024" stroke="#FFCC68" stroke-opacity=".55" stroke-width="2"/>
+  <text x="712" y="132" font-size="12" letter-spacing="1" fill="#8F96BA">source collection</text>
+  <rect x="712" y="142" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="712" y="170" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="712" y="198" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <circle cx="728" cy="153" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <circle cx="728" cy="181" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <circle cx="728" cy="209" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <text x="740" y="158" font-size="11" class="primary">document 01</text>
+  <text x="740" y="186" font-size="11" class="primary">document 02</text>
+  <text x="740" y="214" font-size="11" class="primary">document 03</text>
+  <rect x="712" y="232" width="380" height="34" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".8"/>
+  <text x="732" y="254" font-size="12" class="primary">vector + keyword search</text>
+  <circle cx="1068" cy="249" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <rect x="712" y="278" width="180" height="38" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".75"/>
+  <rect x="912" y="278" width="180" height="38" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".75"/>
+  <text x="732" y="302" font-size="12" class="primary">passage 01</text>
+  <text x="932" y="302" font-size="12" class="primary">passage 02</text>
+  <text x="1068" y="302" text-anchor="end" font-size="11" fill="#FFCC68">selected</text>
+  <line x1="902" y1="316" x2="902" y2="374" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrowAmber)"/>
+  <rect x="824" y="382" width="156" height="42" rx="21" fill="#0F1221" stroke="#FFCC68" stroke-width="2"/>
+  <circle cx="848" cy="403" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <text x="864" y="408" font-size="15" class="primary">model</text>
+
+  <rect x="579" y="242" width="42" height="42" rx="21" fill="#0F1221" stroke="#343A5F" stroke-width="2"/>
+  <text x="600" y="268" text-anchor="middle" font-size="15" font-weight="700" class="secondary">vs</text>
+
+  <text x="600" y="535" text-anchor="middle" font-size="40" font-weight="700" letter-spacing="-1" class="primary">RAG vs. Long Context</text>
+  <text x="600" y="574" text-anchor="middle" font-size="18" class="secondary">When do you actually need retrieval?</text>
+</svg>

--- a/public/blog/rag-vs-long-context/images/long-context-flow.svg
+++ b/public/blog/rag-vs-long-context/images/long-context-flow.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="360" viewBox="0 0 900 360" role="img" aria-labelledby="title desc">
+  <title id="title">Long context flow</title>
+  <desc id="desc">System instructions, conversation history, project specification, and source files enter one context window before reaching the model.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#343A5F" stroke-opacity=".22"/>
+    </pattern>
+    <filter id="glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#67E8F9"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .primary { fill: #F6F7FF; }
+      .secondary { fill: #B4BAD8; }
+      .muted { fill: #8F96BA; }
+    </style>
+  </defs>
+  <rect width="900" height="360" rx="12" fill="url(#bg)"/>
+  <rect width="900" height="360" rx="12" fill="url(#grid)"/>
+  <text x="450" y="35" text-anchor="middle" font-size="17" font-weight="700" letter-spacing="3" fill="#67E8F9">LONG CONTEXT</text>
+  <circle cx="570" cy="29" r="4" fill="#67E8F9" filter="url(#glow)"/>
+
+  <rect x="28" y="70" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="125" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="180" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="235" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <circle cx="48" cy="91" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="146" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="201" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="256" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <text x="64" y="97" font-size="14" class="primary">system instructions</text>
+  <text x="64" y="152" font-size="14" class="primary">conversation history</text>
+  <text x="64" y="207" font-size="14" class="primary">project specification</text>
+  <text x="64" y="262" font-size="14" class="primary">source files</text>
+
+  <line x1="252" y1="173" x2="300" y2="173" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="316" y="77" width="300" height="192" rx="12" fill="#0B1024" stroke="#67E8F9" stroke-width="2"/>
+  <text x="466" y="112" text-anchor="middle" font-size="16" font-weight="700" class="primary">context window</text>
+  <text x="466" y="137" text-anchor="middle" font-size="12" class="muted">one prompt</text>
+  <rect x="348" y="158" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="348" y="190" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="348" y="222" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <text x="466" y="175" text-anchor="middle" font-size="11" class="secondary">all inputs included</text>
+  <text x="466" y="207" text-anchor="middle" font-size="11" class="secondary">relationships stay visible</text>
+  <text x="466" y="239" text-anchor="middle" font-size="11" class="secondary">no retrieval step</text>
+
+  <line x1="616" y1="173" x2="670" y2="173" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="686" y="143" width="176" height="60" rx="30" fill="#0F1221" stroke="#67E8F9" stroke-width="2"/>
+  <circle cx="714" cy="173" r="5" fill="#67E8F9" filter="url(#glow)"/>
+  <text x="734" y="179" font-size="16" class="primary">model</text>
+</svg>

--- a/public/blog/rag-vs-long-context/images/rag-flow.svg
+++ b/public/blog/rag-vs-long-context/images/rag-flow.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="360" viewBox="0 0 900 360" role="img" aria-labelledby="title desc">
+  <title id="title">RAG flow</title>
+  <desc id="desc">A user question moves through query preparation, vector and keyword search, ranking and filtering, selected passages, and the model.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#343A5F" stroke-opacity=".22"/>
+    </pattern>
+    <filter id="glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#FFCC68"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .primary { fill: #F6F7FF; }
+      .secondary { fill: #B4BAD8; }
+      .muted { fill: #8F96BA; }
+    </style>
+  </defs>
+  <rect width="900" height="360" rx="12" fill="url(#bg)"/>
+  <rect width="900" height="360" rx="12" fill="url(#grid)"/>
+  <text x="450" y="35" text-anchor="middle" font-size="17" font-weight="700" letter-spacing="3" fill="#FFCC68">RAG</text>
+  <circle cx="497" cy="29" r="4" fill="#FFCC68" filter="url(#glow)"/>
+
+  <rect x="20" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#FFCC68" stroke-width="2"/>
+  <rect x="165" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="310" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="455" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="600" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#FFCC68" stroke-opacity=".8"/>
+  <rect x="745" y="140" width="135" height="72" rx="36" fill="#0F1221" stroke="#FFCC68" stroke-width="2"/>
+
+  <circle cx="42" cy="176" r="5" fill="#FFCC68" filter="url(#glow)"/>
+  <text x="80" y="171" text-anchor="middle" font-size="13" class="primary">user</text>
+  <text x="80" y="191" text-anchor="middle" font-size="13" class="primary">question</text>
+  <text x="225" y="171" text-anchor="middle" font-size="12" class="primary">query</text>
+  <text x="225" y="191" text-anchor="middle" font-size="12" class="primary">preparation</text>
+  <text x="370" y="166" text-anchor="middle" font-size="11" class="primary">vector +</text>
+  <text x="370" y="186" text-anchor="middle" font-size="11" class="primary">keyword search</text>
+  <text x="515" y="171" text-anchor="middle" font-size="12" class="primary">rank &amp;</text>
+  <text x="515" y="191" text-anchor="middle" font-size="12" class="primary">filter</text>
+  <text x="660" y="171" text-anchor="middle" font-size="12" class="primary">selected</text>
+  <text x="660" y="191" text-anchor="middle" font-size="12" class="primary">passages</text>
+  <circle cx="770" cy="176" r="5" fill="#FFCC68" filter="url(#glow)"/>
+  <text x="824" y="181" text-anchor="middle" font-size="15" class="primary">model</text>
+
+  <line x1="140" y1="176" x2="157" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="285" y1="176" x2="302" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="430" y1="176" x2="447" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="575" y1="176" x2="592" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="720" y1="176" x2="737" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <text x="450" y="272" text-anchor="middle" font-size="12" class="muted">search narrows the evidence before generation</text>
+</svg>

--- a/src/content/blog/rag-vs-long-context/images/cover.svg
+++ b/src/content/blog/rag-vs-long-context/images/cover.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">RAG vs. Long Context</title>
+  <desc id="desc">A dark two-panel comparison showing all documents entering one long context window on the left, and retrieval selecting passages before the model on the right.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#222640"/>
+      <stop offset="1" stop-color="#1B1F36"/>
+    </linearGradient>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M32 0H0V32" fill="none" stroke="#343A5F" stroke-opacity=".2"/>
+    </pattern>
+    <filter id="glowCyan" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glowAmber" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowCyan" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#67E8F9"/>
+    </marker>
+    <marker id="arrowAmber" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#FFCC68"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .muted { fill: #8F96BA; }
+      .secondary { fill: #B4BAD8; }
+      .primary { fill: #F6F7FF; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="500" fill="url(#grid)"/>
+
+  <rect x="44" y="42" width="508" height="420" rx="12" fill="url(#panel)" stroke="#343A5F" stroke-width="2"/>
+  <rect x="648" y="42" width="508" height="420" rx="12" fill="url(#panel)" stroke="#343A5F" stroke-width="2"/>
+
+  <text x="76" y="82" font-size="18" font-weight="700" letter-spacing="2" fill="#67E8F9">LONG CONTEXT</text>
+  <circle cx="518" cy="76" r="4" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="680" y="82" font-size="18" font-weight="700" letter-spacing="2" fill="#FFCC68">RAG</text>
+  <circle cx="1122" cy="76" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+
+  <rect x="86" y="104" width="424" height="246" rx="10" fill="#0B1024" stroke="#67E8F9" stroke-opacity=".55" stroke-width="2"/>
+  <text x="108" y="132" font-size="12" letter-spacing="1" fill="#8F96BA">context window / one prompt</text>
+  <rect x="108" y="148" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="108" y="208" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="108" y="268" width="380" height="48" rx="8" fill="#222640" stroke="#343A5F"/>
+  <circle cx="128" cy="172" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <circle cx="128" cy="232" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <circle cx="128" cy="292" r="5" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="146" y="177" font-size="14" class="primary">document 01</text>
+  <text x="146" y="237" font-size="14" class="primary">document 02</text>
+  <text x="146" y="297" font-size="14" class="primary">document 03</text>
+  <text x="476" y="177" text-anchor="end" font-size="12" class="muted">fits</text>
+  <text x="476" y="237" text-anchor="end" font-size="12" class="muted">fits</text>
+  <text x="476" y="297" text-anchor="end" font-size="12" class="muted">fits</text>
+  <line x1="298" y1="350" x2="298" y2="374" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrowCyan)"/>
+  <rect x="220" y="382" width="156" height="42" rx="21" fill="#0F1221" stroke="#67E8F9" stroke-width="2"/>
+  <circle cx="244" cy="403" r="4" fill="#67E8F9" filter="url(#glowCyan)"/>
+  <text x="260" y="408" font-size="15" class="primary">model</text>
+
+  <rect x="690" y="104" width="424" height="246" rx="10" fill="#0B1024" stroke="#FFCC68" stroke-opacity=".55" stroke-width="2"/>
+  <text x="712" y="132" font-size="12" letter-spacing="1" fill="#8F96BA">source collection</text>
+  <rect x="712" y="142" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="712" y="170" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="712" y="198" width="380" height="22" rx="6" fill="#222640" stroke="#343A5F"/>
+  <circle cx="728" cy="153" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <circle cx="728" cy="181" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <circle cx="728" cy="209" r="3" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <text x="740" y="158" font-size="11" class="primary">document 01</text>
+  <text x="740" y="186" font-size="11" class="primary">document 02</text>
+  <text x="740" y="214" font-size="11" class="primary">document 03</text>
+  <rect x="712" y="232" width="380" height="34" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".8"/>
+  <text x="732" y="254" font-size="12" class="primary">vector + keyword search</text>
+  <circle cx="1068" cy="249" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <rect x="712" y="278" width="180" height="38" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".75"/>
+  <rect x="912" y="278" width="180" height="38" rx="8" fill="#222640" stroke="#FFCC68" stroke-opacity=".75"/>
+  <text x="732" y="302" font-size="12" class="primary">passage 01</text>
+  <text x="932" y="302" font-size="12" class="primary">passage 02</text>
+  <text x="1068" y="302" text-anchor="end" font-size="11" fill="#FFCC68">selected</text>
+  <line x1="902" y1="316" x2="902" y2="374" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrowAmber)"/>
+  <rect x="824" y="382" width="156" height="42" rx="21" fill="#0F1221" stroke="#FFCC68" stroke-width="2"/>
+  <circle cx="848" cy="403" r="4" fill="#FFCC68" filter="url(#glowAmber)"/>
+  <text x="864" y="408" font-size="15" class="primary">model</text>
+
+  <rect x="579" y="242" width="42" height="42" rx="21" fill="#0F1221" stroke="#343A5F" stroke-width="2"/>
+  <text x="600" y="268" text-anchor="middle" font-size="15" font-weight="700" class="secondary">vs</text>
+
+  <text x="600" y="535" text-anchor="middle" font-size="40" font-weight="700" letter-spacing="-1" class="primary">RAG vs. Long Context</text>
+  <text x="600" y="574" text-anchor="middle" font-size="18" class="secondary">When do you actually need retrieval?</text>
+</svg>

--- a/src/content/blog/rag-vs-long-context/images/long-context-flow.svg
+++ b/src/content/blog/rag-vs-long-context/images/long-context-flow.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="360" viewBox="0 0 900 360" role="img" aria-labelledby="title desc">
+  <title id="title">Long context flow</title>
+  <desc id="desc">System instructions, conversation history, project specification, and source files enter one context window before reaching the model.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#343A5F" stroke-opacity=".22"/>
+    </pattern>
+    <filter id="glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#67E8F9"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .primary { fill: #F6F7FF; }
+      .secondary { fill: #B4BAD8; }
+      .muted { fill: #8F96BA; }
+    </style>
+  </defs>
+  <rect width="900" height="360" rx="12" fill="url(#bg)"/>
+  <rect width="900" height="360" rx="12" fill="url(#grid)"/>
+  <text x="450" y="35" text-anchor="middle" font-size="17" font-weight="700" letter-spacing="3" fill="#67E8F9">LONG CONTEXT</text>
+  <circle cx="570" cy="29" r="4" fill="#67E8F9" filter="url(#glow)"/>
+
+  <rect x="28" y="70" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="125" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="180" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <rect x="28" y="235" width="224" height="42" rx="8" fill="#222640" stroke="#343A5F"/>
+  <circle cx="48" cy="91" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="146" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="201" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <circle cx="48" cy="256" r="4" fill="#67E8F9" filter="url(#glow)"/>
+  <text x="64" y="97" font-size="14" class="primary">system instructions</text>
+  <text x="64" y="152" font-size="14" class="primary">conversation history</text>
+  <text x="64" y="207" font-size="14" class="primary">project specification</text>
+  <text x="64" y="262" font-size="14" class="primary">source files</text>
+
+  <line x1="252" y1="173" x2="300" y2="173" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="316" y="77" width="300" height="192" rx="12" fill="#0B1024" stroke="#67E8F9" stroke-width="2"/>
+  <text x="466" y="112" text-anchor="middle" font-size="16" font-weight="700" class="primary">context window</text>
+  <text x="466" y="137" text-anchor="middle" font-size="12" class="muted">one prompt</text>
+  <rect x="348" y="158" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="348" y="190" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <rect x="348" y="222" width="236" height="24" rx="6" fill="#222640" stroke="#343A5F"/>
+  <text x="466" y="175" text-anchor="middle" font-size="11" class="secondary">all inputs included</text>
+  <text x="466" y="207" text-anchor="middle" font-size="11" class="secondary">relationships stay visible</text>
+  <text x="466" y="239" text-anchor="middle" font-size="11" class="secondary">no retrieval step</text>
+
+  <line x1="616" y1="173" x2="670" y2="173" stroke="#67E8F9" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="686" y="143" width="176" height="60" rx="30" fill="#0F1221" stroke="#67E8F9" stroke-width="2"/>
+  <circle cx="714" cy="173" r="5" fill="#67E8F9" filter="url(#glow)"/>
+  <text x="734" y="179" font-size="16" class="primary">model</text>
+</svg>

--- a/src/content/blog/rag-vs-long-context/images/rag-flow.svg
+++ b/src/content/blog/rag-vs-long-context/images/rag-flow.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="360" viewBox="0 0 900 360" role="img" aria-labelledby="title desc">
+  <title id="title">RAG flow</title>
+  <desc id="desc">A user question moves through query preparation, vector and keyword search, ranking and filtering, selected passages, and the model.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F1221"/>
+      <stop offset="1" stop-color="#171A2F"/>
+    </linearGradient>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#343A5F" stroke-opacity=".22"/>
+    </pattern>
+    <filter id="glow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#FFCC68"/>
+    </marker>
+    <style>
+      text { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .primary { fill: #F6F7FF; }
+      .secondary { fill: #B4BAD8; }
+      .muted { fill: #8F96BA; }
+    </style>
+  </defs>
+  <rect width="900" height="360" rx="12" fill="url(#bg)"/>
+  <rect width="900" height="360" rx="12" fill="url(#grid)"/>
+  <text x="450" y="35" text-anchor="middle" font-size="17" font-weight="700" letter-spacing="3" fill="#FFCC68">RAG</text>
+  <circle cx="497" cy="29" r="4" fill="#FFCC68" filter="url(#glow)"/>
+
+  <rect x="20" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#FFCC68" stroke-width="2"/>
+  <rect x="165" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="310" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="455" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#343A5F"/>
+  <rect x="600" y="140" width="120" height="72" rx="10" fill="#222640" stroke="#FFCC68" stroke-opacity=".8"/>
+  <rect x="745" y="140" width="135" height="72" rx="36" fill="#0F1221" stroke="#FFCC68" stroke-width="2"/>
+
+  <circle cx="42" cy="176" r="5" fill="#FFCC68" filter="url(#glow)"/>
+  <text x="80" y="171" text-anchor="middle" font-size="13" class="primary">user</text>
+  <text x="80" y="191" text-anchor="middle" font-size="13" class="primary">question</text>
+  <text x="225" y="171" text-anchor="middle" font-size="12" class="primary">query</text>
+  <text x="225" y="191" text-anchor="middle" font-size="12" class="primary">preparation</text>
+  <text x="370" y="166" text-anchor="middle" font-size="11" class="primary">vector +</text>
+  <text x="370" y="186" text-anchor="middle" font-size="11" class="primary">keyword search</text>
+  <text x="515" y="171" text-anchor="middle" font-size="12" class="primary">rank &amp;</text>
+  <text x="515" y="191" text-anchor="middle" font-size="12" class="primary">filter</text>
+  <text x="660" y="171" text-anchor="middle" font-size="12" class="primary">selected</text>
+  <text x="660" y="191" text-anchor="middle" font-size="12" class="primary">passages</text>
+  <circle cx="770" cy="176" r="5" fill="#FFCC68" filter="url(#glow)"/>
+  <text x="824" y="181" text-anchor="middle" font-size="15" class="primary">model</text>
+
+  <line x1="140" y1="176" x2="157" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="285" y1="176" x2="302" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="430" y1="176" x2="447" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="575" y1="176" x2="592" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="720" y1="176" x2="737" y2="176" stroke="#FFCC68" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <text x="450" y="272" text-anchor="middle" font-size="12" class="muted">search narrows the evidence before generation</text>
+</svg>

--- a/src/content/blog/rag-vs-long-context/index.mdx
+++ b/src/content/blog/rag-vs-long-context/index.mdx
@@ -1,0 +1,198 @@
+---
+title: 'RAG vs Long Context: When Do You Actually Need Retrieval?'
+description: 'A practical guide to choosing between retrieval-augmented generation and long-context prompting, with tradeoffs, a decision framework, and patterns for using both.'
+date: 2026-08-31
+author: 'Piyush Mehta'
+tags:
+  - 'AI'
+  - 'Large Language Models'
+  - 'RAG'
+  - 'System Design'
+  - 'Developer Tools'
+ogTemplate: 'tech'
+ogTheme: 'dark'
+image:
+  url: '/blog/rag-vs-long-context/images/cover.svg'
+  alt: 'A two-panel comparison of long context, where all documents enter one prompt, and RAG, where selected passages reach the model'
+draft: false
+---
+
+A model with a large context window can take in a lot of material in one request. That makes it tempting to put every document you have into the prompt and call the problem solved. Retrieval-augmented generation (RAG) takes the opposite first step: find a small, relevant set of passages, then ask the model to use those passages.
+
+![RAG vs long context hero](/blog/rag-vs-long-context/images/cover.svg)
+
+Neither approach is automatically better. They solve different problems. Long context is a way to give a model more of the input. RAG is a way to decide which input it should see, usually from a collection that is too large, too changeable, or too sensitive to send in full.
+
+The better question is not "Which one is more advanced?" It is "What information should be available for this request, and how much work should happen before the model sees it?"
+
+## The distinction
+
+In a long-context design, the application assembles the relevant conversation, instructions, and documents into one prompt:
+
+![Long context: everything goes into one prompt](/blog/rag-vs-long-context/images/long-context-flow.svg)
+
+```text
+system instructions
+conversation history
+project specification
+several source files
+user question
+```
+
+The model receives that bundle directly. A larger context window lets the bundle contain more tokens, but the application still has to choose and format the material. Long context does not mean the model automatically knows where the relevant paragraph is. It only means the paragraph can fit.
+
+RAG adds a retrieval step:
+
+![RAG: retrieve only relevant passages](/blog/rag-vs-long-context/images/rag-flow.svg)
+
+```text
+user question
+  -> query preparation
+  -> search over an indexed collection
+  -> ranking and filtering
+  -> selected passages in the prompt
+  -> model response
+```
+
+The index might use keyword search, vector similarity, metadata filters, or a combination. The retrieved passages are evidence for one generation request. The source collection can be updated independently of the model. That makes RAG useful for private or frequently changing information.
+
+Fine-tuning is a different tool again. It changes model behavior or teaches patterns through training examples. It is generally not a substitute for making a changing knowledge base available at request time.
+
+## When long context fits
+
+Use long context when the complete input is already known and reasonably sized.
+
+Consider a document review. If a user asks for a summary of one contract, loading the contract in full avoids the risk that a retrieval query misses an exception or a definition. The same applies to comparing two design documents, reviewing a pull request with a bounded diff, or extracting fields from a form whose structure is important.
+
+Long context also works well when the task depends on relationships across the whole input. A model may need to see the introduction and an appendix together, compare repeated terms, or track a decision through a sequence of meeting notes. Retrieval can return useful fragments, but it can also hide the connections between them.
+
+Long context also has operational benefits:
+
+- The request path has fewer moving parts. There is no index, embedding pipeline, or retrieval service to operate.
+- Debugging is more direct. You can inspect the prompt and see the input the model received.
+- There is no retrieval recall problem for material that you deliberately included.
+- A small, temporary corpus does not need to be indexed before it can be used.
+
+This does not make long context free. More input usually means more tokens to process, which can increase latency and cost. Large prompts can also contain distractors. Models may give less attention to a detail surrounded by a great deal of unrelated text, even when the detail technically fits in the window. Context limits are also hard limits, so a design that works for today's document may fail when the document grows.
+
+Start with long context when the corpus for a request is bounded, the whole corpus matters, and adding retrieval would mostly add infrastructure rather than improve the answer.
+
+## When RAG is worth adding
+
+RAG fits when the collection is larger than a useful prompt or when only a small part of it matters for each request.
+
+A product support assistant over many manuals, an internal search assistant over changing policies, and a coding tool for a large repository all fit this pattern. Sending the entire collection for every question is wasteful and can make the model's job harder. Retrieval narrows the evidence to passages that have a plausible relationship to the question.
+
+RAG is also a good fit when knowledge changes more often than the model or application is deployed. Updating a document and its index can be a faster operational path than retraining a model or rebuilding a huge prompt at request time. It can also help enforce boundaries: retrieve only documents the requesting user is allowed to see, rather than placing an entire private corpus in a shared prompt assembly step.
+
+RAG shifts correctness into the retrieval pipeline. A fluent answer based on the wrong passages is still wrong. Common failure modes include:
+
+- The relevant passage may not have been indexed, may have been split poorly, or may not have ranked highly enough.
+- The user's wording may differ from the words in the source, and vector or keyword search alone may miss it.
+- A chunk may omit the heading, table context, or definition needed to interpret it.
+- Stale and current documents may both be retrieved without a clear precedence rule.
+- Retrieval may ignore document or row-level authorization.
+
+RAG is more than "add a vector database." It is a search system with a generation step attached. Search quality, freshness, permissions, and observability deserve the same attention as the model call.
+
+## A decision framework
+
+Ask these questions before choosing an architecture.
+
+### 1. What is the corpus for one request?
+
+Count the material the model genuinely needs, not every file that exists. If it is a single document, a bounded set of records, or a small diff, long context usually fits well. If it is a large repository or a growing document collection, retrieval is more likely to pay off.
+
+Estimate the worst case, not just the average. A prompt that fits most of the time but overflows on the largest customer account needs a defined behavior for that account.
+
+### 2. Does the whole corpus matter?
+
+If the answer requires global comparison, ordering, or reconciliation, include the complete relevant input or use a staged process that preserves those relationships. If each question usually concerns a few independent facts, retrieving those facts is more efficient.
+
+### 3. How often does the information change?
+
+For stable source material, either approach may work. For information that changes daily, retrieval gives you a direct update path, provided the indexing and deletion process is reliable. A cache or direct database query may be even simpler when the data is structured and the question can be translated safely into a query.
+
+### 4. What is the cost of missing a passage?
+
+For a casual brainstorming tool, an occasional missed result may be acceptable. For compliance, operations, or code changes, it may not be. Higher stakes call for explicit source coverage checks, citations or links back to source records, and a refusal path when evidence is insufficient. Retrieval should not be used to create false confidence.
+
+### 5. What latency and cost can you accept?
+
+Long context spends work on every included token. RAG spends work on search, ranking, and a smaller generation prompt. Measure the complete request, including indexing and updates where relevant. A direct database lookup can beat both if the information is tabular and the query is well defined.
+
+In practice, choose among three options:
+
+| Situation                                               | Start with            |
+| ------------------------------------------------------- | --------------------- |
+| One bounded document or small input                     | Long context          |
+| Large, changing, permissioned collection                | RAG                   |
+| Structured records with predictable questions           | Database or API query |
+| Large collection plus requests needing broad comparison | Hybrid approach       |
+
+## Combine them when needed
+
+Many production systems use both methods. Retrieval first narrows a large corpus. Long context then holds the selected evidence, conversation, and task instructions together.
+
+A support assistant can retrieve the relevant product manuals and account records, then place the top passages plus a short conversation history in one prompt. A code assistant can search a repository for likely files, load those files and their tests, and ask the model to reason over the resulting set. The retrieval step controls scale, while the context window preserves enough local structure for the model to work accurately.
+
+One hybrid pipeline looks like this:
+
+```ts
+const candidates = await search({
+  query: userQuestion,
+  filters: { tenantId, allowed: true },
+  limit: 20,
+});
+
+const evidence = rerank(candidates).slice(0, 8);
+const prompt = buildPrompt({
+  question: userQuestion,
+  conversation: recentMessages,
+  evidence,
+});
+
+return generate(prompt);
+```
+
+Those numbers are configuration, not fixed rules. The right amount of evidence depends on chunk size, document structure, question type, and model behavior. More passages can improve coverage, but they can also add duplicates and distraction.
+
+When a question needs broad coverage, use multiple retrieval queries or a two-stage flow. One stage can identify relevant documents, and another can load coherent sections from those documents. For a comparison, retrieve the source groups separately and label them clearly rather than mixing fragments into one undifferentiated list.
+
+## Implementation details
+
+### Preserve document structure
+
+Chunking should retain enough context. Keep headings, page or section identifiers, document version, and source URLs alongside the text. Splitting in the middle of a table or a definition can make a technically relevant chunk misleading. Small overlaps can help with boundaries, but overlap is not a replacement for thoughtful segmentation.
+
+### Combine search methods
+
+Keyword search is good at exact names, error messages, identifiers, and version numbers. Vector search is useful when the question and source use different wording. A hybrid search that combines both often handles a wider range of developer questions than either one alone.
+
+Metadata filters matter too. Filter by tenant, product, language, document type, and effective date before or during ranking. Relevance must not override authorization.
+
+### Treat freshness as a data problem
+
+An index needs an ingestion path, update detection, retry behavior, and deletion handling. Store a document version or content hash so reindexing is deterministic. Decide what happens when indexing lags behind the source of truth. For time-sensitive answers, expose the document's effective date to the model and to the user.
+
+### Design for insufficient evidence
+
+Tell the model to answer from the supplied evidence and to say when it cannot support an answer. Your application can enforce this further by requiring a minimum retrieval score, checking that results pass authorization, or routing low-confidence requests to a human or a normal search experience.
+
+Do not treat a similarity score as a calibrated probability. Validate retrieval with representative questions and expected source documents. Track misses as well as successful generations. A useful evaluation set includes ambiguous terms, exact identifiers, questions with no answer, and questions that require joining multiple documents.
+
+### Make the pipeline observable
+
+Log query intent, applied filters, document and chunk identifiers, ranks, retrieval latency, model latency, token counts, and whether the answer used the expected sources. This gives you enough to diagnose a bad answer without leaking sensitive content. Redact or protect the actual text according to its sensitivity.
+
+Long-context systems need similar observability. Record which documents were included, how much of the context budget they used, and when truncation happened. Silent truncation is dangerous because the request can still produce a polished answer.
+
+## Start with a comparison
+
+Build the smallest version that lets you compare answer quality. For a bounded corpus, pass the full input to the model and save representative questions and expected evidence. When the corpus grows, add retrieval while keeping the same evaluation set. Compare answer quality alongside source coverage, latency, token usage, and failure behavior.
+
+If retrieval does not improve the cases that motivated it, the problem may be chunking, query construction, ranking, or source quality rather than the model. If long context is accurate but too expensive, reduce repeated instructions, summarize stable history, or retrieve only the parts that vary.
+
+Match the architecture to the information. Use long context when the complete, bounded input is the evidence. Use RAG when search is needed to select evidence from a larger or changing collection. Use both when you need retrieval for scale and context for coherent reasoning.
+
+Retrieval does not make an architecture more mature, and a larger context window does not replace search. Choose the smallest system that gives the model the right information, keeps permissions and freshness explicit, and fails clearly when the evidence is not there.

--- a/tests/migration-smoke.spec.ts
+++ b/tests/migration-smoke.spec.ts
@@ -24,6 +24,25 @@ test.describe('astro v6 migration smoke', () => {
     expect(page.url()).toContain('/blog/');
     await expect(page.locator('article').first()).toBeVisible();
   });
+  test('RAG article images load as SVG assets', async ({ page }) => {
+    await page.goto('/blog/rag-vs-long-context', { waitUntil: 'networkidle' });
+
+    const imageAlts = [
+      'A two-panel comparison of long context, where all documents enter one prompt, and RAG, where selected passages reach the model',
+      'RAG vs long context hero',
+      'Long context: everything goes into one prompt',
+      'RAG: retrieve only relevant passages',
+    ];
+
+    for (const alt of imageAlts) {
+      const image = page.locator('article img[alt="' + alt + '"]');
+      await expect(image).toHaveCount(1);
+      const src = await image.getAttribute('src');
+      expect(src, alt + ' should have a source URL').toBeTruthy();
+      expect(src, alt + ' should not use Astro image optimization for SVG').not.toContain('/_image');
+      await expect.poll(() => image.evaluate((element) => (element as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
+    }
+  });
 
   test('blog index shows non-zero published pieces', async ({ page }) => {
     await page.goto('/blog/', { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Summary
- Add a developer-focused RAG vs long-context article.
- Add a cover and two inline SVG diagrams, with public mirrors.
- Fix image URLs to avoid Astro's SVG optimizer.
- Add a focused regression test covering all four rendered SVG image elements.

## Tests
- `bun run check` (passed)
- `env -u CI ASTRO_DEV_BACKGROUND=1 bunx playwright test tests/migration-smoke.spec.ts -g "RAG article images load as SVG assets" --project=chromium` (passed)
